### PR TITLE
Added generic whereNot() method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,22 +119,16 @@ See [this](examples/README.md) page for more information.
   - [QueryBuilder: Filters](#querybuilder-filters)
     - [where()](#where)
     - [orWhere()](#orwhere)
+    - [whereNot()](#wherenot)
+    - [orWhereNot()](#orwherenot)
     - [whereIn()](#wherein)
-    - [orWhereIn()](#orwherein)
-    - [whereNotIn()](#wherenotin)
-    - [orWhereNotIn()](#orwherenotin)
+    - [orWhereIn()](#orwherein)    
     - [whereBetween()](#wherebetween)
-    - [orWhereBetween()](#orwherebetween)
-    - [whereNotBetween()](#wherenotbetween)
-    - [orWhereNotBetween()](#orwherenotbetween)
+    - [orWhereBetween()](#orwherebetween)    
     - [whereColumn()](#wherecolumn)
-    - [orWhereColumn()](#orwherecolumn)
-    - [whereNotColumn()](#wherenotcolumn)
-    - [orWhereNotColumn()](#orwherenotcolumn)
+    - [orWhereColumn()](#orwherecolumn)    
     - [whereInterval()](#whereinterval)
-    - [orWhereInterval()](#orwhereinterval)
-    - [whereNotInterval()](#wherenotinterval)    
-    - [orWhereNotInterval()](#orwherenotinterval)
+    - [orWhereInterval()](#orwhereinterval)    
     - [whereFlags()](#whereflags)
     - [orWhereFlags()](#orwhereflags) 
   - [QueryBuilder: Extractions](#querybuilder-extractions)
@@ -1157,6 +1151,32 @@ However, this is not recommended and should not be needed.
 Same as `where()`, but now we will join previous added filters with a `or` instead of an `and`.
 
 
+#### `whereNot()`
+
+With this filter you can build a filterset which should NOT match. It is thus inverted.
+
+Example:
+```php
+$builder->whereNot(function (FilterBuilder $filterBuilder) {
+    $filterBuilder->orWhere('namespace', 'Talk');
+    $filterBuilder->orWhere('namespace', 'Main');
+});
+```
+
+You can use this in combination with all the other filters!
+
+This method has the following arguments:
+
+| **Type** | **Optional/Required** | **Argument**     | **Example** | **Description**                                                                                                                                              |
+|----------|-----------------------|------------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Closure  | Required              | `$filterBuilder` | "flags"     | A closure function which will receive a `FilterBuilder` object. All applied filters will be inverted.                                                        |
+| string   | Optional              | `$boolean`       | "and"       | This influences how this filter will be joined with previous added filters. Should both filters apply ("and") or one or the other ("or") ? Default is "and". |
+ 
+
+#### `orWhereNot()`
+
+Same as `whereNot()`, but now we will join previous added filters with a `or` instead of an `and`.
+
 #### `whereIn()`
 
 With this method you can filter on records using multiple values. 
@@ -1172,18 +1192,6 @@ This method has the following arguments:
 #### `orWhereIn()`
 
 Same as `whereIn()`, but now we will join previous added filters with a `or` instead of an `and`.
-
-
-#### `whereNotIn()`
-
-This works the same as `whereIn()`, only now we will check if the dimension is NOT in the given values. See `whereIn()` 
-for more details.  
-
-
-#### `orWhereNotIn()`
-
-Same as `whereNotIn()`, but now we will join previous added filters with a `or` instead of an `and`.
-
 
 #### `whereBetween()`
 
@@ -1207,17 +1215,6 @@ This method has the following arguments:
 #### `orWhereBetween()`
 
 Same as `whereBetween()`, but now we will join previous added filters with a `or` instead of an `and`.
-
-
-#### `whereNotBetween()`
-
-This works the same as `whereBetween()`, only now we will check if the dimension is NOT in between the given values. 
-See `whereBetween()` for more details.  
-
-
-#### `orWhereNotBetween()`
-
-Same as `whereNotBetween()`, but now we will join previous added filters with a `or` instead of an `and`.
 
 
 #### `whereColumn()`
@@ -1247,17 +1244,6 @@ The `whereColumn()` filter has the following arguments:
 #### `orWhereColumn()`
 
 Same as `whereColumn()`, but now we will join previous added filters with a `or` instead of an `and`.
-
-
-#### `whereNotColumn()`
-
-The `whereNotColumn()` filter works exactly the same as the `whereColumn()` filter, only now it will only return rows
-where `$dimensionA` is different then `$dimensionB`.  
-
-
-#### `orWhereNotColumn()`
-
-Same as `whereNotColumn()`, but now we will join previous added filters with a `or` instead of an `and`.
 
 
 #### `whereInterval()`
@@ -1296,16 +1282,6 @@ $builder->whereInterval('__time', ['12-09-2019/13-09-2019', '19-09-2019/20-09-20
 
 Same as `whereInterval()`, but now we will join previous added filters with a `or` instead of an `and`.
 
-
-#### `whereNotInterval()`
-
-This works the same as `whereInterval()`, only now we will check if the dimension is NOT matching the given intervals. 
-See `whereInterval()` for more details.  
-
-
-#### `orWhereNotInterval()`
-
-Same as `whereNotInterval()`, but now we will join previous added filters with a `or` instead of an `and`.
 
 #### `whereFlags`
 

--- a/src/Concerns/HasFilter.php
+++ b/src/Concerns/HasFilter.php
@@ -150,6 +150,41 @@ trait HasFilter
     }
 
     /**
+     * Build a where selection which is inverted
+     *
+     * @param \Closure $filterBuilder A closure which will receive a FilterBuilder instance.
+     * @param string   $boolean       This influences how this filter will be joined with previous added filters.
+     *                                Should both filters apply ("and") or one or the other ("or") ? Default is "and".
+     *
+     * @return $this
+     */
+    public function whereNot(Closure $filterBuilder, $boolean = 'and')
+    {
+        // lets create a bew builder object where the user can mess around with
+        $builder = new FilterBuilder();
+
+        // call the user function
+        call_user_func($filterBuilder, $builder);
+
+        // Now retrieve the filter which was created and add it to our current filter set.
+        $filter = $builder->getFilter();
+
+        return $this->where(new NotFilter($filter), null, null, null, $boolean);
+    }
+
+    /**
+     * Build a where selection which is inverted
+     *
+     * @param \Closure $filterBuilder A closure which will receive a FilterBuilder instance.
+     *
+     * @return $this
+     */
+    public function orWhereNot(Closure $filterBuilder)
+    {
+        return $this->whereNot($filterBuilder, 'or');
+    }
+
+    /**
      * This applies a filter, only it will join previous added filters with an "or" instead of an "and".
      * See the documentation of the "where" method for more information
      *
@@ -359,6 +394,7 @@ trait HasFilter
      *                                   "and".
      *
      * @return $this
+     * @deprecated Use the whereNot() method combined with a whereColumn instead.
      */
     public function whereNotColumn($dimensionA, $dimensionB, string $boolean = 'and')
     {
@@ -494,6 +530,7 @@ trait HasFilter
      *                                   "and".
      *
      * @return $this
+     * @deprecated Use the whereNot() method combined with a whereBetween instead.
      */
     public function whereNotBetween(
         string $dimension,
@@ -529,6 +566,7 @@ trait HasFilter
      *                                   numeric, otherwise it will be "lexicographic"
      *
      * @return $this
+     * @deprecated Use the whereNot() method combined with a whereBetween instead.
      */
     public function orWhereNotBetween(
         string $dimension,
@@ -552,6 +590,7 @@ trait HasFilter
      *                                  "and".
      *
      * @return $this
+     * @deprecated Use the whereNot() method combined with a whereIn instead.
      */
     public function whereNotIn(string $dimension, array $items, Closure $extraction = null, string $boolean = 'and')
     {
@@ -569,6 +608,7 @@ trait HasFilter
      * @param \Closure|null $extraction An extraction function to extract a different value from the dimension.
      *
      * @return $this
+     * @deprecated Use the orWhereNot() method combined with a whereIn instead.
      */
     public function orWhereNotIn(string $dimension, array $items, Closure $extraction = null)
     {
@@ -598,6 +638,7 @@ trait HasFilter
      *                                  "and".
      *
      * @return $this
+     * @deprecated Use the whereNot() method combined with a whereInterval instead.
      */
     public function whereNotInterval(
         string $dimension,
@@ -634,6 +675,7 @@ trait HasFilter
      * @param \Closure|null $extraction Extraction function to extract a different value from the dimension.
      *
      * @return $this
+     * @deprecated Use the orWhereNot() method combined with a whereInterval instead.
      */
     public function orWhereNotInterval(string $dimension, array $intervals, Closure $extraction = null)
     {


### PR DESCRIPTION
This generic whereNot method replaces all variants of the whereNot<Filter> methods.