### PR TITLE
OrFilter fix

### DIFF
--- a/src/Filters/OrFilter.php
+++ b/src/Filters/OrFilter.php
@@ -3,8 +3,31 @@ declare(strict_types=1);
 
 namespace Level23\Druid\Filters;
 
-class OrFilter extends AndFilter
+class OrFilter implements FilterInterface, LogicalExpressionFilterInterface
 {
+    /**
+     * @var array|\Level23\Druid\Filters\FilterInterface[]
+     */
+    protected $filters;
+
+    /**
+     * AndFilter constructor.
+     *
+     * @param array|\Level23\Druid\Filters\FilterInterface[] $filters List of DruidFilter classes.
+     */
+    public function __construct(array $filters)
+    {
+        $this->filters = $filters;
+    }
+
+    /**
+     * @param \Level23\Druid\Filters\FilterInterface $filter
+     */
+    public function addFilter(FilterInterface $filter)
+    {
+        $this->filters[] = $filter;
+    }
+
     /**
      * Return the filter as it can be used in the druid query.
      *
@@ -12,10 +35,15 @@ class OrFilter extends AndFilter
      */
     public function toArray(): array
     {
-        $result = parent::toArray();
+        $fields = [];
 
-        $result['type'] = 'or';
+        foreach ($this->filters as $filter) {
+            $fields[] = $filter->toArray();
+        }
 
-        return $result;
+        return [
+            'type'   => 'or',
+            'fields' => $fields,
+        ];
     }
 }

--- a/tests/Filters/CombinationsTest.php
+++ b/tests/Filters/CombinationsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace tests\Filters;
+
+use tests\TestCase;
+use Level23\Druid\DruidClient;
+use Level23\Druid\Filters\FilterBuilder;
+
+class CombinationsTest extends TestCase
+{
+    /**
+     * @throws \Exception
+     */
+    public function testAndAndOrFilterCombination()
+    {
+        $client = new DruidClient([]);
+        $query  = $client->query('source');
+        $query->interval('2020-01-01', '2020-01-02');
+
+        $query->where(function (FilterBuilder $builder) {
+            $builder->orWhere('foo', '=', 'bar');
+            $builder->orWhere('foo', '=', 'baz');
+        });
+
+        $query->where('bar', '=', 'qux');
+
+        $result = $query->toArray();
+
+        $expectedFilter = [
+            'type'   => 'and',
+            'fields' => [
+                [
+                    'type'   => 'or',
+                    'fields' => [
+                        [
+                            'type'      => 'selector',
+                            'dimension' => 'foo',
+                            'value'     => 'bar',
+                        ],
+                        [
+                            'type'      => 'selector',
+                            'dimension' => 'foo',
+                            'value'     => 'baz',
+                        ],
+                    ],
+                ],
+                [
+                    'type'      => 'selector',
+                    'dimension' => 'bar',
+                    'value'     => 'qux',
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedFilter, $result['filter']);
+    }
+}


### PR DESCRIPTION
Fixes using the combination of OrFilter and AndFilters.

Because the OrFilter extended the AndFilter the check for adding an AndFilter after an OrFilter resulted in thinking the current filter is an AndFilter, which causes the AndFilter to be added to the already added OrFilters.

Example code:
```php
$client = new DruidClient([]);
$query  = $client->query('source');
$query->interval('2020-01-01', '2020-01-02');

$query->where(function (FilterBuilder $builder) {
    $builder->orWhere('foo', '=', 'bar');
    $builder->orWhere('foo', '=', 'baz');
});
$query->where('bar', '=', 'qux');
```

In the old situation this resulted in:
```json
"filter": {
    "type": "or",
    "fields": [
        {
            "type": "selector",
            "dimension": "foo",
            "value": "bar"
        },
        {
            "type": "selector",
            "dimension": "foo",
            "value": "baz"
        },
        {
            "type": "selector",
            "dimension": "bar",
            "value": "qux"
        }
    ]
}
```

After the fix this will generate the following code as expected:
```json
"filter": {
    "type": "and",
    "fields": [
        {
            "type": "or",
            "fields": [
                {
                    "type": "selector",
                    "dimension": "foo",
                    "value": "bar"
                },
                {
                    "type": "selector",
                    "dimension": "foo",
                    "value": "baz"
                }
            ]
        },
        {
            "type": "selector",
            "dimension": "bar",
            "value": "qux"
        }
    ]
}
```
