### PR TITLE
Fix datatype for selectVirtual

### DIFF
--- a/build/phpunit.xml
+++ b/build/phpunit.xml
@@ -1,30 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="../tests/bootstrap.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         executionOrder="default"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="../tests/bootstrap.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         stopOnError="false"
-         stopOnIncomplete="false"
-         stopOnSkipped="false"
-         stopOnRisky="false"
-         timeoutForSmallTests="1"
-         timeoutForMediumTests="10"
-         timeoutForLargeTests="60"
          verbose="true">
-    <testsuites>
-        <testsuite name="phpunit">
-            <directory suffix="Test.php">../tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">../src</directory>
-        </whitelist>
-    </filter>
+  <coverage>
+    <include>
+      <directory suffix=".php">../src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="phpunit">
+      <directory>../tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Queries/QueryBuilder.php
+++ b/src/Queries/QueryBuilder.php
@@ -133,7 +133,7 @@ class QueryBuilder
     public function selectVirtual(string $expression, string $as, $outputType = DataType::STRING)
     {
         $this->virtualColumn($expression, $as, $outputType);
-        $this->select($as);
+        $this->select($as, $as, null, $outputType);
 
         return $this;
     }

--- a/tests/Queries/QueryBuilderTest.php
+++ b/tests/Queries/QueryBuilderTest.php
@@ -115,16 +115,24 @@ class QueryBuilderTest extends TestCase
     {
         Mockery::mock('overload:' . VirtualColumn::class)
             ->shouldReceive('__construct')
-            ->with('concat(foo, bar)', 'fooBar', 'string');
+            ->with('foo + bar', 'fooBar', 'float');
 
-        $response = $this->builder->selectVirtual('concat(foo, bar)', 'fooBar');
+        $response = $this->builder->selectVirtual('foo + bar', 'fooBar', 'float');
 
-        $this->assertEquals([
+        $this->assertNotEquals([
             'type'       => 'default',
             'dimension'  => 'fooBar',
             'outputType' => 'string',
             'outputName' => 'fooBar',
         ], $this->builder->getDimensions()[0]->toArray());
+
+        $this->assertEquals([
+            'type'       => 'default',
+            'dimension'  => 'fooBar',
+            'outputType' => 'float',
+            'outputName' => 'fooBar',
+        ], $this->builder->getDimensions()[0]->toArray());
+
 
         $this->assertEquals($this->builder, $response);
     }


### PR DESCRIPTION
When using `selectVirtual` the specified datatype was not used for the selected column, this PR fixes that.

Additionally cleaned up phpunit.xml as phpunit suggested to update it, added XML scheme and removed all the defaults values.