### PR TITLE
NULL filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 **v3.0.3**
 
+- Added `whereNull()` and `orWhereNull()` filter methods.
+- Changed `where()` filter method to accept `NULL` as value. 
 - Added `getLogger` method to retrieve the current logger. Changed MetadataBuilder. Log a warning when no interval
   was found by the given shorthand name (like "first" or "last")
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Changelog
 
+**v3.0.3**
+
+- Added `getLogger` method to retrieve the current logger. Changed MetadataBuilder. Log a warning when no interval
+  was found by the given shorthand name (like "first" or "last")
+
+**v3.0.2**
+
+- Added rowCount method to fetch the number of rows over a specific interval
+- 
 **v3.0.1**
 
 - Added support to retrieve all dataSources from druid.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ DRUID_ROUTER_URL=http://druid-router.url:8080
 
 ## Todo's
 
+- Implement the [Equality filter](https://druid.apache.org/docs/latest/querying/filters#equality-filter)
 - Support for building metricSpec and DimensionSpec in CompactTaskBuilder
 - Implement hadoop based batch ingestion (indexing)
 - Implement Avro Stream and Avro OCF input formats.
@@ -141,6 +142,8 @@ for more information.
         - [orWhere()](#orwhere)
         - [whereNot()](#wherenot)
         - [orWhereNot()](#orwherenot)
+        - [whereNull()](#wherenull)
+        - [orWhereNull()](#orwherenull)
         - [whereIn()](#wherein)
         - [orWhereIn()](#orwherein)
         - [whereBetween()](#wherebetween)
@@ -1538,7 +1541,7 @@ This method uses the following arguments:
 |----------|-----------------------|---------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | string   | Required              | `$dimension`  | "cityName"         | The dimension which you want to filter.                                                                                                                                                 |
 | string   | Required              | `$operator`   | "="                | The operator which you want to use to filter. See below for a complete list of supported operators.                                                                                     |
-| mixed    | Required              | `$value`      | "Auburn"           | The value which you want to use in your filter comparison                                                                                                                               |
+| mixed    | Optional              | `$value`      | "Auburn"           | The value which you want to use in your filter comparison. Set to null to match against NULL values.                                                                                    |
 | Closure  | Optional              | `$extraction` | See example below. | A closure which builds one or more extraction function. These are applied _before_ the filter will be applied. So the filter will use the value returned by the extraction function(s). |
 | string   | Optional              | `$boolean`    | "and" / "or"       | This influences how this filter will be joined with previous added filters. Should both filters apply ("and") or one or the other ("or") ? Default is "and".                            |
 
@@ -1642,6 +1645,36 @@ This method has the following arguments:
 #### `orWhereNot()`
 
 Same as `whereNot()`, but now we will join previous added filters with a `or` instead of an `and`.
+
+#### `whereNull()`
+
+Druid has changed its NULL handling. You can now configure it to store `NULL` values by configuring 
+`druid.generic.useDefaultValueForNull=false`.
+
+If this is configured, you can filter on NULL values with this filter. 
+
+This method has the following arguments:
+
+| **Type** | **Optional/Required** | **Argument** | **Example** | **Description**                                                                                                                                              |
+|----------|-----------------------|--------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| string   | Required              | `$column`    | "city"      | The column or virtual column which you want to filter on null values.                                                                                        |
+| string   | Optional              | `$boolean`   | "and"       | This influences how this filter will be joined with previous added filters. Should both filters apply ("and") or one or the other ("or") ? Default is "and". |
+
+Example:
+
+```php
+// filter on all places where city name is NULL.
+$builder->whereNull('city'); 
+
+// filter on all places where the country is NOT NULL!
+$builder->whereNot(function (FilterBuilder $filterBuilder) {
+    $filterBuilder->whereNull('country');    
+});
+```
+
+#### `orWhereNull()`
+
+Same as `whereNull()`, but now we will join previous added filters with a `or` instead of an `and`.
 
 #### `whereIn()`
 

--- a/src/DruidClient.php
+++ b/src/DruidClient.php
@@ -87,7 +87,7 @@ class DruidClient
     /**
      * Create a new query using the druid query builder.
      *
-     * @param string $dataSource
+     * @param string             $dataSource
      * @param string|Granularity $granularity
      *
      * @return \Level23\Druid\Queries\QueryBuilder
@@ -148,7 +148,7 @@ class DruidClient
         /** @var array<string,array<mixed>|int|string> $payload */
         $payload = $task->toArray();
 
-        $this->log('Executing druid task: '. var_export($payload, true));
+        $this->log('Executing druid task: ' . var_export($payload, true));
 
         /** @var string[] $result */
         $result = $this->executeRawRequest(
@@ -264,6 +264,16 @@ class DruidClient
     }
 
     /**
+     * Return the logger if one is set.
+     *
+     * @return \Psr\Log\LoggerInterface|null
+     */
+    public function getLogger(): ?LoggerInterface
+    {
+        return $this->logger;
+    }
+
+    /**
      * Set a custom guzzle client which should be used.
      *
      * @param GuzzleClient $client
@@ -327,7 +337,7 @@ class DruidClient
             if (!is_array($row)) {
                 throw new InvalidArgumentException('We failed to parse response!');
             }
-        } catch (InvalidArgumentException|JsonException $exception ) {
+        } catch (InvalidArgumentException|JsonException $exception) {
             $this->log('We failed to decode druid response. ');
             $this->log('Status code: ' . $response->getStatusCode());
             $this->log('Response body: ' . $contents);

--- a/src/Filters/NullFilter.php
+++ b/src/Filters/NullFilter.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Level23\Druid\Filters;
+
+use Level23\Druid\Extractions\ExtractionInterface;
+
+/**
+ * Class NullFilter
+ *
+ * @see     https://druid.apache.org/docs/latest/querying/filters#null-filter
+ * @package Level23\Druid\Filters
+ */
+class NullFilter implements FilterInterface
+{
+    protected string $column;
+
+    protected ?ExtractionInterface $extractionFunction;
+
+    /**
+     * NullFilter constructor.
+     *
+     * @param string $column Input column or virtual column name to filter.
+     */
+    public function __construct(string $column)
+    {
+        $this->column = $column;
+    }
+
+    /**
+     * Return the filter as it can be used in the druid query.
+     *
+     * @return array<string,string|array<string,string|int|bool|array<mixed>>>
+     */
+    public function toArray(): array
+    {
+        $result = [
+            'type'   => 'null',
+            'column' => $this->column,
+        ];
+
+        return $result;
+    }
+}

--- a/src/Filters/SelectorFilter.php
+++ b/src/Filters/SelectorFilter.php
@@ -9,7 +9,7 @@ class SelectorFilter implements FilterInterface
 {
     protected string $dimension;
 
-    protected string $value;
+    protected ?string $value;
 
     protected ?ExtractionInterface $extractionFunction;
 
@@ -17,12 +17,12 @@ class SelectorFilter implements FilterInterface
      * InFilter constructor.
      *
      * @param string                   $dimension
-     * @param string                   $value
+     * @param string|null              $value
      * @param ExtractionInterface|null $extractionFunction
      */
     public function __construct(
         string $dimension,
-        string $value,
+        ?string $value,
         ?ExtractionInterface $extractionFunction = null
     ) {
         $this->value              = $value;
@@ -33,7 +33,7 @@ class SelectorFilter implements FilterInterface
     /**
      * Return the filter as it can be used in the druid query.
      *
-     * @return array<string,string|array<string,string|int|bool|array<mixed>>>
+     * @return array<string,string|null|array<string,string|int|bool|array<mixed>>>
      */
     public function toArray(): array
     {

--- a/src/Metadata/MetadataBuilder.php
+++ b/src/Metadata/MetadataBuilder.php
@@ -381,13 +381,20 @@ class MetadataBuilder
             throw new InvalidArgumentException('Only shorthand "first" and "last" are supported!');
         }
 
-        $intervals = array_keys($this->intervals($dataSource));
+        $rawIntervals = $this->intervals($dataSource);
 
-        if ($shortHand == 'last') {
-            return $intervals[0] ?? '';
+        $intervals = array_keys($rawIntervals);
+
+        $result = ($shortHand == 'last') ? ($intervals[0] ?? '') : ($intervals[count($intervals) - 1] ?? '');
+
+        if (empty($result)) {
+            $this->client->getLogger()?->warning(
+                'Failed to get ' . $shortHand . ' interval! ' .
+                'We got ' . count($rawIntervals) . ' intervals: ' . var_export($intervals, true)
+            );
         }
 
-        return $intervals[count($intervals) - 1] ?? '';
+        return $result;
     }
 
     /**

--- a/tests/DruidClientTest.php
+++ b/tests/DruidClientTest.php
@@ -245,10 +245,15 @@ class DruidClientTest extends TestCase
         $client = $this->mockDruidClient();
         $client->makePartial();
 
+        $this->assertNull($client->getLogger());
+
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('debug')->twice();
 
         $client->setLogger($logger);
+
+        // Test that our getter also works.
+        $this->assertEquals($logger, $client->getLogger());
 
         $payload = ['task' => 'here'];
 

--- a/tests/Filters/NullFilterTest.php
+++ b/tests/Filters/NullFilterTest.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Level23\Druid\Tests\Filters;
+
+use Level23\Druid\Tests\TestCase;
+use Level23\Druid\Filters\NullFilter;
+
+class NullFilterTest extends TestCase
+{
+    public function testFilter(): void
+    {
+        $expected = [
+            'type'   => 'null',
+            'column' => 'name',
+        ];
+
+        $filter = new NullFilter('name');
+
+        $this->assertEquals($expected, $filter->toArray());
+    }
+}


### PR DESCRIPTION
- Added `whereNull()` and `orWhereNull()` filter methods.
- Changed `where()` filter method to accept `NULL` as value. 
- Added `getLogger` method to retrieve the current logger. Changed MetadataBuilder. Log a warning when no interval
  was found by the given shorthand name (like "first" or "last")