### PR TITLE
Adding expression PostAggregator

### DIFF
--- a/src/Concerns/HasPostAggregations.php
+++ b/src/Concerns/HasPostAggregations.php
@@ -18,6 +18,7 @@ use Level23\Druid\PostAggregations\PostAggregatorInterface;
 use Level23\Druid\PostAggregations\QuantilesPostAggregator;
 use Level23\Druid\PostAggregations\HistogramPostAggregator;
 use Level23\Druid\PostAggregations\ArithmeticPostAggregator;
+use Level23\Druid\PostAggregations\ExpressionPostAggregator;
 use Level23\Druid\PostAggregations\JavaScriptPostAggregator;
 use Level23\Druid\PostAggregations\FieldAccessPostAggregator;
 use Level23\Druid\PostAggregations\SketchSummaryPostAggregator;
@@ -602,5 +603,15 @@ trait HasPostAggregations
     public function getPostAggregations(): array
     {
         return $this->postAggregations;
+    }
+
+    public function expression(string $as, $expression): self
+    {
+        $this->postAggregations[] = new ExpressionPostAggregator(
+            $as,
+            $expression
+        );
+
+        return $this;
     }
 }

--- a/src/PostAggregations/ExpressionPostAggregator.php
+++ b/src/PostAggregations/ExpressionPostAggregator.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Level23\Druid\PostAggregations;
+
+use Level23\Druid\PostAggregations\PostAggregatorInterface;
+
+class ExpressionPostAggregator implements PostAggregatorInterface
+{
+    protected string $outputName;
+
+    protected string $expression;
+
+    public function __construct(
+        string $outputName,
+        string $expression
+    ) {
+        $this->outputName   = $outputName;
+        $this->expression   = $expression;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'type'          => 'expression',
+            'name'          => $this->outputName,
+            'expression'    => $this->expression,
+        ];
+    }
+}


### PR DESCRIPTION
Hello guys,

Last week I needed more complex postAggregation operations so I integrated post aggregation by expression.

It works like this. We have somekind of operation like so:

```
// We want this post aggregation operation to be calculated by Druid, 
$operation = "((CAST(\"sys_unique_event_count\", 'DOUBLE') / \"sys_event_count\") * 100)";

$queryBuilder->expression("example_dim", $operation);
```

```
"postAggregations": [
        {
            "type": "expression",
            "name": "example_dim",
            "expression": "((CAST(\"sys_unique_event_count\", 'DOUBLE') / \"sys_event_count\") * 100)"
        }
    ],
```

Thank you! I really like your druid php lib